### PR TITLE
Allow codesniffer plugin for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,9 @@
         ]
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
Allow dealerdirect/phpcodesniffer-composer-installer as a plugin in composer