### PR TITLE
Support PHP 8.2 and 8.3 in addition to 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1']
+        php-version: ['8.1', '8.2', '8.3']
     name: PHP ${{ matrix.php-version }}
 
     steps:
@@ -54,7 +54,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
 
       - name: Composer install
@@ -73,7 +73,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
 
       - name: composer install

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ A library for fetching data from [Norwegian Football API service Fotballdata](ht
 ### Installation:
 `composer install avolle/fotballdata`
 
+### Supports:
+* PHP 8.1
+* PHP 8.2
+* PHP 8.3
+
 ### Gotchas
 As `match` is a [protected control structure token](https://www.php.net/manual/en/control-structures.match.php) 
 for PHP from version 8.0 and up, we need to alias the `Match` entity. Therefore all Match results use the `Game` entity.


### PR DESCRIPTION
While the package supported 8.2 and 8.3 already, this PR removes the [deprecated usage of dynamic properties](https://php.watch/versions/8.2/dynamic-properties-deprecated). 